### PR TITLE
Update ranges to be inclusive of the end number

### DIFF
--- a/parser/__init__.py
+++ b/parser/__init__.py
@@ -103,32 +103,31 @@ def parse_date_str(dt: str) -> str:
     for short_day in SHORT_DAYS:
         if short_day in dt:
             dt = dt.replace(short_day, "%a")
-    for short_month in SHORT_MONTHS:
-        if short_month in dt:
-            dt = dt.replace(short_month, "%b")
     for ampm in AM_PM:
         if ampm in dt:
             dt = dt.replace(ampm, "%p")
 
     two_digit_results = TWO_DIGIT_REGEX.findall(dt)
     if len(two_digit_results) == 3:
-        if int(two_digit_results[0]) in range(0, 23) and int(two_digit_results[1]) in range(0, 59) and int(two_digit_results[2]) in range(0, 59):
-            if int(two_digit_results[0]) in range(13, 23):
-                dt = dt.replace(two_digit_results[0], "%H")
-            if int(two_digit_results[0]) in range(0, 12):
-                dt = dt.replace(two_digit_results[0], "%I")
-            dt = dt.replace(two_digit_results[1], "%M")
-            dt = dt.replace(two_digit_results[2], "%S")
+        if int(two_digit_results[0]) in range(0, 24) and int(two_digit_results[1]) in range(0, 60) and int(two_digit_results[2]) in range(0, 60):
+            if int(two_digit_results[0]) in range(13, 24):
+                dt = dt.replace(two_digit_results[0], "%H", 1)
+            elif int(two_digit_results[0]) in range(1, 13):
+                dt = dt.replace(two_digit_results[0], "%I", 1)
+            else:
+                dt = dt.replace(two_digit_results[0], "%H", 1)
+            dt = dt.replace(two_digit_results[1], "%M", 1)
+            dt = dt.replace(two_digit_results[2], "%S", 1)
     if len(two_digit_results) == 2:
-        if int(two_digit_results[0]) in range(1, 12) and int(two_digit_results[1]) in range(1, 31):
-            dt = dt.replace(two_digit_results[0], "%m")
-            dt = dt.replace(two_digit_results[1], "%d")
-        if int(two_digit_results[0]) in range(1, 31) and int(two_digit_results[1]) in range(1, 12):
-            dt = dt.replace(two_digit_results[0], "%d")
-            dt = dt.replace(two_digit_results[1], "%m")
+        if int(two_digit_results[0]) in range(1, 13) and int(two_digit_results[1]) in range(1, 32):
+            dt = dt.replace(two_digit_results[0], "%m", 1)
+            dt = dt.replace(two_digit_results[1], "%d", 1)
+        if int(two_digit_results[0]) in range(1, 32) and int(two_digit_results[1]) in range(1, 13):
+            dt = dt.replace(two_digit_results[0], "%d", 1)
+            dt = dt.replace(two_digit_results[1], "%m", 1)
     if len(two_digit_results) == 1:
-        if int(two_digit_results[0]) in range(1, 31):
-            dt = dt.replace(two_digit_results[0], "%d")
+        if int(two_digit_results[0]) in range(1, 32):
+            dt = dt.replace(two_digit_results[0], "%d", 1)
 
 
 


### PR DESCRIPTION
Previously this would not detect a date such as "2020-01-31" or "2019-12-01" because "12" and "31" were not valid values for months or years. Looking through this code, this same issue appears to apply to the other ranges as well so they have all been adjusted.

This also fixes a bug where if a date like "2020-01-01" was used, it would properly detect it as a 2 digit date but it would result in "%Y-%m-%m" instead of "%Y-%m-%d" because "01" would be replaced with "%m" twice. You can use the third argument to `str.replace` to tell Python to only replace 1 instance, which solves this issue.

This also removes a duplicate check for `SHORT_MONTHS` which was already being done above.