### PR TITLE
Case insensitive matching

### DIFF
--- a/parser/__init__.py
+++ b/parser/__init__.py
@@ -92,17 +92,21 @@ def parse_date_str(dt: str) -> str:
         dt = dt.replace(year_results[0], "%Y")
 
     for long_month in LONG_MONTHS:
-        if long_month in dt:
-            dt = dt.replace(long_month, "%B")
+        insensitive_long_month = re.compile(re.escape(long_month), re.IGNORECASE)
+        if re.search(insensitive_long_month, dt):
+            dt = insensitive_long_month.sub("%B", dt)
     for short_month in SHORT_MONTHS:
-        if short_month in dt:
-            dt = dt.replace(short_month, "%b")
+        insensitive_short_month = re.compile(re.escape(short_month), re.IGNORECASE)
+        if re.search(insensitive_short_month, dt):
+            dt = insensitive_short_month.sub("%b", dt)
     for long_day in LONG_DAYS:
-        if long_day in dt:
-            dt = dt.replace(long_day, "%A")
+        insensitive_long_day = re.compile(re.escape(long_day), re.IGNORECASE)
+        if re.search(insensitive_long_day, dt):
+            dt = insensitive_long_day.sub("%A", dt)
     for short_day in SHORT_DAYS:
-        if short_day in dt:
-            dt = dt.replace(short_day, "%a")
+        insensitive_short_day = re.compile(re.escape(short_day), re.IGNORECASE)
+        if re.search(insensitive_short_day, dt):
+            dt = insensitive_short_day.sub("%a", dt)
     for ampm in AM_PM:
         if ampm in dt:
             dt = dt.replace(ampm, "%p")

--- a/parser/tests/test_parser.py
+++ b/parser/tests/test_parser.py
@@ -21,8 +21,18 @@ class TestParser(TestCase):
         result = parse_date_str(input_format)
         self.assertEqual("%d %b %Y", result)
 
+    def test_parser__ddShortMoNtHyyyy_space_delim(self):
+        input_format = "21 FeB 2020"
+        result = parse_date_str(input_format)
+        self.assertEqual("%d %b %Y", result)
+
     def test_parser__ddLongMonthyyyy_space_delim(self):
         input_format = "21 February 2020"
+        result = parse_date_str(input_format)
+        self.assertEqual("%d %B %Y", result)
+
+    def test_parser__ddLongMoNtHyyyy_space_delim(self):
+        input_format = "21 FeBrUaRy 2020"
         result = parse_date_str(input_format)
         self.assertEqual("%d %B %Y", result)
 
@@ -33,6 +43,16 @@ class TestParser(TestCase):
 
     def test_parser__shortDayddthShortMonthYYYY(self):
         input_format = "Mon 9th Jan 2020"
+        result = parse_date_str(input_format)
+        self.assertEqual("%a %dth %b %Y", result)
+
+    def test_parser__shortDayddthShortMONTHYYYY(self):
+        input_format = "Mon 9th JAN 2020"
+        result = parse_date_str(input_format)
+        self.assertEqual("%a %dth %b %Y", result)
+
+    def test_parser__shortDAYddthShortMONTHYYYY(self):
+        input_format = "MON 9th JAN 2020"
         result = parse_date_str(input_format)
         self.assertEqual("%a %dth %b %Y", result)
 


### PR DESCRIPTION
This change provides case insensitive matching for days and months. This allows the user to input strings like

- MON 9th JAN 2020
- Mon 9th JAN 2020
- monday 9th january 2020

Being case insensitive also allows for mixed case strings like
- 21 FeBrUaRy 2020
